### PR TITLE
Recaptcha error.

### DIFF
--- a/datatypes/ezcomcomments/ezcomcommentstype.php
+++ b/datatypes/ezcomcomments/ezcomcommentstype.php
@@ -18,7 +18,7 @@ class ezcomCommentsType extends eZDataType
     function __construct()
     {
         parent::__construct( self::DATA_TYPE_STRING, ezpI18n::tr( 'ezcomments/datatype', 'Comments', 'Datatype name'),
-                             array( 'serialize_supported' => true) );
+                             array( 'serialize_supported' => true ) );
     }
 
     /**
@@ -42,7 +42,6 @@ class ezcomCommentsType extends eZDataType
             if( $publicKey === '' || $privateKey === '' )
             {
                 eZDebug::writeNotice( 'reCAPTCHA key is not set up. For help please visit http://projects.ez.no/ezcomments', __METHOD__ );
-                return eZInputValidator::STATE_INVALID;
             }
         }
         


### PR DESCRIPTION
When recaptcha is not configured globally, but on a siteaccess basis (every toplevel domain requires a unique recaptcha code) storing the content class will fail on a STATE_INVALID because the recaptcha is not configured for the admin siteaccess.
My suggestion is to just display the warning message, without sending the STATE_INVALID.
