### PR TITLE
language_id isn't mandatory for comment_count why for comment_list

### DIFF
--- a/packages/ezcomments_extension/ezextension/ezcomments/classes/ezcomcomment.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/classes/ezcomcomment.php
@@ -179,7 +179,10 @@ class ezcomComment extends eZPersistentObject
     {
         $cond = array();
         $cond['contentobject_id'] = $contentObjectID;
-        $cond['language_id'] = $languageID;
+        if ( $languageID !== false )
+        {
+            $cond['language_id'] = $languageID;
+        }
         if( !is_null( $status ) )
         {
             $cond['status'] = $status;

--- a/packages/ezcomments_extension/ezextension/ezcomments/modules/comment/function_definition.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/modules/comment/function_definition.php
@@ -22,8 +22,8 @@ $FunctionList['comment_list'] = array( 'name' => 'comment_list',
                                                     ),
                                                    array( 'name'=> 'language_id',
                                                           'type'=> 'integer',
-                                                          'required' => true,
-                                                          'default'  => 0
+                                                          'required' => false,
+                                                          'default'  => false
                                                       ),
                                                   array( 'name'=> 'status',
                                                           'type'=>'integer',


### PR DESCRIPTION
In comment_count fetch, the parameter language_id isn't mandatory. This pull request allow to use also comment_list without language_id parameter.
