### PR TITLE
Fixed bug #019388: eZComments proxy support for captcha

### DIFF
--- a/packages/ezcomments_extension/ezextension/ezcomments/classes/recaptchalib.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/classes/recaptchalib.php
@@ -37,7 +37,7 @@
  */
 define("RECAPTCHA_API_SERVER", "http://www.google.com/recaptcha/api");
 define("RECAPTCHA_API_SECURE_SERVER", "https://www.google.com/recaptcha/api");
-define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
+define("RECAPTCHA_VERIFY_SERVER", "http://www.google.com");
 
 /**
  * Encodes the given data into a query string format
@@ -68,25 +68,7 @@ function _recaptcha_http_post($host, $path, $data, $port = 80) {
 
         $req = _recaptcha_qsencode ($data);
 
-        $http_request  = "POST $path HTTP/1.0\r\n";
-        $http_request .= "Host: $host\r\n";
-        $http_request .= "Content-Type: application/x-www-form-urlencoded;\r\n";
-        $http_request .= "Content-Length: " . strlen($req) . "\r\n";
-        $http_request .= "User-Agent: reCAPTCHA/PHP\r\n";
-        $http_request .= "\r\n";
-        $http_request .= $req;
-
-        $response = '';
-        if( false == ( $fs = @fsockopen($host, $port, $errno, $errstr, 10) ) ) {
-                die ('Could not open socket');
-        }
-
-        fwrite($fs, $http_request);
-
-        while ( !feof($fs) )
-                $response .= fgets($fs, 1160); // One TCP-IP packet
-        fclose($fs);
-        $response = explode("\r\n\r\n", $response, 2);
+        $response = eZHTTPTool::getDataByURL( $host . $path . '?' . $req, false, 'reCAPTCHA/PHP' );
 
         return $response;
 }
@@ -178,7 +160,7 @@ function recaptcha_check_answer ($privkey, $remoteip, $challenge, $response, $ex
                                                  ) + $extra_params
                                           );
 
-        $answers = explode ("\n", $response [1]);
+        $answers = explode ("\n", $response );
         $recaptcha_response = new ReCaptchaResponse();
 
         if (trim ($answers [0]) == 'true') {


### PR DESCRIPTION
While eZPublish allows proxy support for requests like URL check (see site.ini[ProxySettings]), eZComments doesn't take care of this configuration.

This results in the impossibility to use eZComments, protected with Captcha, on environments where proxy usage is mandatory.
