### PR TITLE
Fixed bug #019508: recaptcha remote url have changed

### DIFF
--- a/packages/ezcomments_extension/ezextension/ezcomments/classes/recaptchalib.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/classes/recaptchalib.php
@@ -2,13 +2,13 @@
 /*
  * This is a PHP library that handles calling reCAPTCHA.
  *    - Documentation and latest version
- *          http://recaptcha.net/plugins/php/
+ *          https://developers.google.com/recaptcha/docs/php
  *    - Get a reCAPTCHA API Key
  *          https://www.google.com/recaptcha/admin/create
  *    - Discussion group
  *          http://groups.google.com/group/recaptcha
  *
- * Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net
+ * Copyright (c) 2007-2012 reCAPTCHA -- http://www.google.com/recaptcha
  * AUTHORS:
  *   Mike Crawford
  *   Ben Maurer

--- a/packages/ezcomments_extension/ezextension/ezcomments/design/standard/templates/class/datatype/edit/ezcomcomments.tpl
+++ b/packages/ezcomments_extension/ezextension/ezcomments/design/standard/templates/class/datatype/edit/ezcomcomments.tpl
@@ -6,7 +6,7 @@
     <div class="message-warning">
             <h4>{'eZ Comments warning: the reCAPTCHA key is not set up properly.'|i18n( 'ezcomments/class/edit' )}</h4>
             <p>
-                {'Please get a reCAPTCHA key from <a href="https://admin.recaptcha.net/recaptcha/createsite" target="_blank">https://admin.recaptcha.net/recaptcha/createsite</a> then set it up in eZ Comments, or disable CAPTCHA feature.'|i18n( 'ezcomments/class/edit')}<br />
+                {'Please get a reCAPTCHA key from <a href="https://www.google.com/recaptcha/admin/create" target="_blank">https://www.google.com/recaptcha/admin/create</a> then set it up in eZ Comments, or disable CAPTCHA feature.'|i18n( 'ezcomments/class/edit')}<br />
                 {'For more details please visit <a href="http://projects.ez.no/ezcomments" target="_blank">http://projects.ez.no/ezcomments</a>.'|i18n( 'ezcomments/class/edit' )}
             </p>
     </div>

--- a/packages/ezcomments_extension/ezextension/ezcomments/extension.xml
+++ b/packages/ezcomments_extension/ezextension/ezcomments/extension.xml
@@ -11,7 +11,7 @@
             <uses>
                 <name>reCAPTCHA PHP Library</name>
                 <license></license>
-                <copyright>Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net</copyright>
+                <copyright>Copyright (c) 2012 reCAPTCHA -- http://www.google.com/recaptcha</copyright>
                 <version>1.11</version>
             </uses>
         </software>

--- a/packages/ezcomments_extension/ezextension/ezcomments/ezinfo.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/ezinfo.php
@@ -18,7 +18,7 @@ class ezcommentsInfo
             'License' => 'GNU General Public License v2.0',
             'Includes the following third-party software' => array( 'Name' => 'reCAPTCHA PHP Library',
                                                                               'Version' => '1.11',
-                                                                              'Copyright' => 'Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net',
+                                                                              'Copyright' => 'Copyright (c) 2007-2012 reCAPTCHA -- http://www.google.com/recaptcha',
                                                                               'License' => '',)
         );
     }

--- a/packages/ezcomments_extension/ezextension/ezcomments/settings/ezcomments.ini.append.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/settings/ezcomments.ini.append.php
@@ -124,12 +124,12 @@ Required=true
 PostVarName=recaptcha_response_field
 
 [RecaptchaSetting]
-#You can get public and private key from https://admin.recaptcha.net/recaptcha/createsite
+#You can get public and private key from https://www.google.com/recaptcha/admin/create
 PublicKey=
 PrivateKey=
 # captcha theme options: red|white|blackglass|clean|custom
 # For more customization, please use 'custom' theeme and override the template.
-# Read more recaptcha API on http://recaptcha.net/apidocs/captcha/client.html
+# Read more recaptcha API on https://developers.google.com/recaptcha/docs/customization
 Theme=custom
 #Current captcha language: en, nl, fr, de, pt, ru, es, tr
 Language=en

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/cat-ES/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/cat-ES/translation.ts
@@ -93,7 +93,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/chi-CN/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/chi-CN/translation.ts
@@ -93,7 +93,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/cro-HR/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/cro-HR/translation.ts
@@ -93,8 +93,8 @@
         <translation>eZ Comments upozorenje: reCAPTCHA ključ nije ispravan.</translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
-        <translation>Zatražite reCAPTCHA ključ na &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; i upišite ga u postavke, ili onemogućite CAPTCHA funkcionalnost.</translation>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <translation>Zatražite reCAPTCHA ključ na &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; i upišite ga u postavke, ili onemogućite CAPTCHA funkcionalnost.</translation>
     </message>
     <message>
         <source>For more details please visit &lt;a href=&quot;http://projects.ez.no/ezcomments&quot; target=&quot;_blank&quot;&gt;http://projects.ez.no/ezcomments&lt;/a&gt;.</source>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/esl-ES/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/esl-ES/translation.ts
@@ -93,7 +93,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/fre-FR/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/fre-FR/translation.ts
@@ -93,8 +93,8 @@
         <translation>Attention : la clé reCAPTCHA n&apos;est définie correctement.</translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
-        <translation>Veuillez récupérer une clé reCAPTCHA sur &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; et configurer eZ Comments pour l&apos;utiliser ou désactiver le CAPTCHA.</translation>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <translation>Veuillez récupérer une clé reCAPTCHA sur &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; et configurer eZ Comments pour l&apos;utiliser ou désactiver le CAPTCHA.</translation>
     </message>
     <message>
         <source>For more details please visit &lt;a href=&quot;http://projects.ez.no/ezcomments&quot; target=&quot;_blank&quot;&gt;http://projects.ez.no/ezcomments&lt;/a&gt;.</source>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/ger-DE/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/ger-DE/translation.ts
@@ -93,7 +93,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/ita-IT/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/ita-IT/translation.ts
@@ -93,8 +93,8 @@
         <translation>Avviso di eZ Comments: la chiave reCAPTCHA non è impostata nel modo giusto.</translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
-        <translation>Preleva una chiave reCAPTCHA da &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; e impostala in eZ Comments, o disabilita la funzione CAPTCHA.</translation>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <translation>Preleva una chiave reCAPTCHA da &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; e impostala in eZ Comments, o disabilita la funzione CAPTCHA.</translation>
     </message>
     <message>
         <source>For more details please visit &lt;a href=&quot;http://projects.ez.no/ezcomments&quot; target=&quot;_blank&quot;&gt;http://projects.ez.no/ezcomments&lt;/a&gt;.</source>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/jpn-JP/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/jpn-JP/translation.ts
@@ -93,8 +93,8 @@
         <translation>eZ Comments警告: reCAPTCHAキーは正しく設定されていません。</translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
-        <translation>&lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt;からreCAPTCHAキーをもらって、eZ Commentsで設定してください。また、キャプチャ機能を無効にすることができます。</translation>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <translation>&lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt;からreCAPTCHAキーをもらって、eZ Commentsで設定してください。また、キャプチャ機能を無効にすることができます。</translation>
     </message>
     <message>
         <source>For more details please visit &lt;a href=&quot;http://projects.ez.no/ezcomments&quot; target=&quot;_blank&quot;&gt;http://projects.ez.no/ezcomments&lt;/a&gt;.</source>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/por-BR/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/por-BR/translation.ts
@@ -421,7 +421,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/packages/ezcomments_extension/ezextension/ezcomments/translations/untranslated/translation.ts
+++ b/packages/ezcomments_extension/ezextension/ezcomments/translations/untranslated/translation.ts
@@ -93,7 +93,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://admin.recaptcha.net/recaptcha/createsite&quot; target=&quot;_blank&quot;&gt;https://admin.recaptcha.net/recaptcha/createsite&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
+        <source>Please get a reCAPTCHA key from &lt;a href=&quot;https://www.google.com/recaptcha/admin/create&quot; target=&quot;_blank&quot;&gt;https://www.google.com/recaptcha/admin/create&lt;/a&gt; then set it up in eZ Comments, or disable CAPTCHA feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
It seems that the urls https://admin.recaptcha.net/recaptcha/createsite and http://recaptcha.net/apidocs/captcha/client.html have both been deactivated by google.
Admin is now available in https://www.google.com/recaptcha/admin/
API is now at http://www.google.com/recaptcha/api

eZComments settings should be updated to reflect this change.
