### PR TITLE
Implement EZP-20849: Move eZ Comments menu from top menu to left content menu

### DIFF
--- a/packages/ezcomments_extension/ezextension/ezcomments/design/admin2/templates/parts/comments/menu.tpl
+++ b/packages/ezcomments_extension/ezextension/ezcomments/design/admin2/templates/parts/comments/menu.tpl
@@ -1,3 +1,5 @@
+{* This template is by default no longer used but kept since some of the translations are used in menu.ini *}
+
 {* See parts/ini_menu.tpl and menu.ini for more info, or parts/setup/menu.tpl for full example *}
 {include uri='design:parts/ini_menu.tpl' ini_section='Leftmenu_ezcomments' i18n_hash=hash(
     'ezcommentsmenu',       'eZ Comments'|i18n( 'comments/comment/menu' ),

--- a/packages/ezcomments_extension/ezextension/ezcomments/modules/comment/module.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/modules/comment/module.php
@@ -56,14 +56,14 @@ $ViewList['delete'] = array(
 
 $ViewList['list'] = array(
                    'functions' => array( 'list' ),
-                   'default_navigation_part' => 'ezcommentsnavigationpart',
+                   'default_navigation_part' => 'ezcontentnavigationpart',
                    'script' => 'list.php',
                    'unordered_params' => array( 'offset' => 'Offset' ),
                    );
 
 $ViewList['removecomments'] = array(
                    'functions' => array( 'removecomments' ),
-                   'default_navigation_part' => 'ezcommentsnavigationpart',
+                   'default_navigation_part' => 'ezcontentnavigationpart',
                    'script' => 'removecomments.php',
                    'params' => array(),
                    );

--- a/packages/ezcomments_extension/ezextension/ezcomments/settings/menu.ini.append.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/settings/menu.ini.append.php
@@ -1,32 +1,8 @@
 <?php /* #?ini charset="utf-8"?
 
-[NavigationPart]
-Part[ezcommentsnavigationpart]=eZComments
-
-[TopAdminMenu]
-Tabs[]=ezcomments
-
-[Topmenu_ezcomments]
-NavigationPartIdentifier=ezcommentsnavigationpart
-Name=eZ Comments
-Tooltip=eZ Comments dashboard
-URL[]
-URL[default]=comment/list
-Enabled[]
-Enabled[default]=true
-Enabled[browse]=false
-Enabled[edit]=false
-Shown[]
-Shown[default]=true
-Shown[edit]=true
-Shown[navigation]=true
-Shown[browse]=true
-
-PolicyList[]=comment/list
-
-[Leftmenu_ezcomments]
-Name=ezcommentsmenu
-LinkNames[]
-Links[]
+[Leftmenu_content]
 Links[commentlist]=comment/list
+LinkNames[commentlist]=Comments list
+PolicyList_commentlist[]=comment/list
+
 */ ?>


### PR DESCRIPTION
This change removes the eZ Comments top menu as it is waste of space to have it's own top menu.

Works best with this PR pulled into eZ Publish legacy first:
https://github.com/ezsystems/ezpublish-legacy/pull/631
