### PR TITLE
EZP-21008: Replaced assertType() with assertInternalType()

### DIFF
--- a/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomcomment_test.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomcomment_test.php
@@ -50,7 +50,7 @@ class ezcomCommentTest extends ezpDatabaseTestCase
         $comment->setAttribute( 'text', 'ezcomComment object test comment.' );
         $comment->store();
 
-        $this->assertType( 'ezcomComment', $comment );
+        $this->assertInstanceOf( 'ezcomComment', $comment );
         $this->assertEquals( 12, $comment->attribute( 'contentobject_id' ) );
         $this->assertEquals( 2, $comment->attribute( 'language_id' ) );
         $this->assertEquals( 21213423, $comment->attribute( 'created' ) );
@@ -74,7 +74,7 @@ class ezcomCommentTest extends ezpDatabaseTestCase
     public function testFetchObject()
     {
         $comment = ezcomComment::fetch( 1 );
-        $this->assertType( 'ezcomComment', $comment );
+        $this->assertInstanceOf( 'ezcomComment', $comment );
         
         $comment = ezcomComment::fetch( 2 );
         $this->assertEquals( null, $comment );

--- a/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomnotification_test.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomnotification_test.php
@@ -42,7 +42,7 @@ class ezcomNotificationTest extends ezpDatabaseTestCase
         $notification->setAttribute( 'status', 1 );        
         $notification->store();
         
-        $this->assertType( 'ezcomNotification', $notification );
+        $this->assertInstanceOf( 'ezcomComment', $notification );
         $this->assertEquals( 12, $notification->attribute( 'contentobject_id' ) );
         $this->assertEquals( 2, $notification->attribute( 'language_id' ) );
         $this->assertEquals( 1, $notification->attribute( 'status' ) );
@@ -58,7 +58,7 @@ class ezcomNotificationTest extends ezpDatabaseTestCase
     public function testFetchObject()
     {
         $notification = ezcomNotification::fetch( 1 );
-        $this->assertType( 'ezcomNotification', $notification );
+        $this->assertInstanceOf( 'ezcomComment', $notification );
         
         $notification = ezcomNotification::fetch( 2 );
         $this->assertEquals( null, $notification );

--- a/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomsubscriber_test.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomsubscriber_test.php
@@ -41,7 +41,7 @@ class ezcomSubscriberTest extends ezpDatabaseTestCase
         $hashString = hash('md5','xc@ez.no');
         $subscriber->setAttribute( 'hash_string', $hashString );
         $subscriber->store();
-        $this->assertType( 'ezcomSubscriber', $subscriber );
+        $this->assertInstanceOf( 'ezcomSubscriber', $subscriber );
         $this->assertEquals( 'xc@ez.no', $subscriber->attribute( 'email' ) );
         $this->assertEquals( 10, $subscriber->attribute( 'user_id' ) );
         $this->assertEquals( 0, $subscriber->attribute( 'enabled' ) );
@@ -55,7 +55,7 @@ class ezcomSubscriberTest extends ezpDatabaseTestCase
     {
         $hashString = hash('md5','xc@ez.no');
         $subscriber = ezcomSubscriber::fetchByHashString( $hashString );
-        $this->assertType( 'ezcomSubscriber', $subscriber );
+        $this->assertInstanceOf( 'ezcomSubscriber', $subscriber );
         $hashString2 = hash('md5','xc11111111111@wfsasdfasf.noddfdsf');
         $subscriber2 = ezcomSubscriber::fetchByHashString( $hashString2 );
         $this->assertEquals( null, $subscriber2 );
@@ -67,7 +67,7 @@ class ezcomSubscriberTest extends ezpDatabaseTestCase
     function testFetchByEmail()
     {
         $subscriber = ezcomSubscriber::fetchByEmail( 'xc@ez.no' );
-        $this->assertType( 'ezcomSubscriber', $subscriber );
+        $this->assertInstanceOf( 'ezcomSubscriber', $subscriber );
         $subscriber = ezcomSubscriber::fetchByEmail( 'xc1111111111@111.com' );
         $this->assertEquals( null, $subscriber );
     }
@@ -78,7 +78,7 @@ class ezcomSubscriberTest extends ezpDatabaseTestCase
     function testFetch()
     {
         $subscriber = ezcomSubscriber::fetch( 1 );
-        $this->assertType( 'ezcomSubscriber', $subscriber );
+        $this->assertInstanceOf( 'ezcomSubscriber', $subscriber );
         $subscriber = ezcomSubscriber::fetch( 100 );
         $this->assertEquals( null, $subscriber );
     }

--- a/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomsubscription_test.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomsubscription_test.php
@@ -44,7 +44,7 @@ class ezcomSubscriptionTest extends ezpDatabaseTestCase
         $subscription->setAttribute( 'enabled', 1 );
         $subscription->store();
 
-        $this->assertType( 'ezcomSubscription', $subscription );
+        $this->assertInstanceOf( 'ezcomSubscription', $subscription );
         $this->assertEquals( 14, $subscription->attribute( 'user_id' ) );
         $this->assertEquals( 4, $subscription->attribute( 'subscriber_id' ) );
         $this->assertEquals( 'ezcomcomment', $subscription->attribute( 'subscription_type' ) );
@@ -59,7 +59,7 @@ class ezcomSubscriptionTest extends ezpDatabaseTestCase
     public function testFetch()
     {
         $subscription = ezcomSubscription::fetch( 1 );
-        $this->assertType( 'ezcomSubscription', $subscription );
+        $this->assertInstanceOf( 'ezcomSubscription', $subscription );
         $subscription = ezcomSubscription::fetch( 1001 );
         $this->assertEquals( null, $subscription );
     }

--- a/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomutility_test.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomutility_test.php
@@ -28,16 +28,16 @@ class ezcomUtilityTest extends ezpDatabaseTestCase
         $url5 = 'http://ez.no';
 
         $result = ezcomUtility::validateURLString( $url1 );
-        $this->assertType( 'string', $result );
+        $this->assertInternalType( 'string', $result );
 
         $result = ezcomUtility::validateURLString( $url2 );
-        $this->assertType( 'string', $result );
+        $this->assertInternalType( 'string', $result );
 
         $result = ezcomUtility::validateURLString( $url3 );
-        $this->assertType( 'string', $result );
+        $this->assertInternalType( 'string', $result );
 
         $result = ezcomUtility::validateURLString( $url4 );
-        $this->assertType( 'string', $result );
+        $this->assertInternalType( 'string', $result );
 
         $result = ezcomUtility::validateURLString( $url5 );
         $this->assertSame( true, $result );


### PR DESCRIPTION
The `assertType()` method has been removed in favor of `assertInternalType()`. `assertType()` has been ["silently" deprecated](https://github.com/sebastianbergmann/phpunit/issues/77#issuecomment-619328) in PHPUnit 3.5 and removed in 3.6.

So, the Unit Tests for eZ Comments will continue to work in PHPUnit 3.5 (the minimum version for eZ Publish), but later will fail (which they did when I installed a new eZ Publish Legacy from the git master branch with the demo extension).

This patch changes `assertType()` calls to `assertInternalType()`.

Cheers
:octocat: Jérôme

https://jira.ez.no/browse/EZP-21008
