### PR TITLE
EZP-21432: Fixed wrong assertions

### DIFF
--- a/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomnotification_test.php
+++ b/packages/ezcomments_extension/ezextension/ezcomments/tests/ezcomnotification_test.php
@@ -42,7 +42,7 @@ class ezcomNotificationTest extends ezpDatabaseTestCase
         $notification->setAttribute( 'status', 1 );        
         $notification->store();
         
-        $this->assertInstanceOf( 'ezcomComment', $notification );
+        $this->assertInstanceOf( 'ezcomNotification', $notification );
         $this->assertEquals( 12, $notification->attribute( 'contentobject_id' ) );
         $this->assertEquals( 2, $notification->attribute( 'language_id' ) );
         $this->assertEquals( 1, $notification->attribute( 'status' ) );
@@ -58,7 +58,7 @@ class ezcomNotificationTest extends ezpDatabaseTestCase
     public function testFetchObject()
     {
         $notification = ezcomNotification::fetch( 1 );
-        $this->assertInstanceOf( 'ezcomComment', $notification );
+        $this->assertInstanceOf( 'ezcomNotification', $notification );
         
         $notification = ezcomNotification::fetch( 2 );
         $this->assertEquals( null, $notification );


### PR DESCRIPTION
Unfortunately, in PR #30, I have introduced two assertion errors in [https://github.com/ezsystems/ezcomments/commit/2cdf323bcf514cd5dd59100e5894865028bdf5b1#L1L45](ackages/ezcomments_extension/ezextension/ezcomments/tests/ezcomnotification_test.php)

`$this->assertInstanceOf( 'ezcomComment', $notification );`

should be

`$this->assertType( 'ezcomNotification', $notification );`

https://jira.ez.no/browse/EZP-21432

Cheers
:octocat: Jérôme
